### PR TITLE
Replace contents of http.Request to add trace features.

### DIFF
--- a/client.go
+++ b/client.go
@@ -200,6 +200,6 @@ func (c *Client) traceRequest(req *http.Request, url string) error {
 				st.ServerName)
 		},
 	}
-	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	*req = *req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
 	return nil
 }


### PR DESCRIPTION
Updated the request with tracing, but the updated request was not used.  Correct that now.