### PR TITLE
Fix NewClient overwriting http.DefaultClient's Jar field

### DIFF
--- a/client.go
+++ b/client.go
@@ -83,7 +83,7 @@ type Config struct {
 // by the given config.
 func NewClient(cfg Config) *Client {
 	certCnt := len(cfg.CACertificates)
-	var hc = http.DefaultClient
+	var hc *http.Client
 	switch {
 	case certCnt > 0:
 		hc = clientWithCerts(cfg)
@@ -98,6 +98,8 @@ func NewClient(cfg Config) *Client {
 		// and some replace the RoundTripper to answer test scenarios.
 		//
 		// https://bugs.launchpad.net/juju/+bug/1888888
+		defaultCopy := *http.DefaultClient
+		hc = &defaultCopy
 	}
 	hc.Jar = cfg.Jar
 	c := &Client{


### PR DESCRIPTION
Create a copy of `http.DefaultClient` before messing with its fields (specifically `Jar`).

This was causing a data race in cmd/jujud/agent tests ([Jenkins failure](https://jenkins.juju.canonical.com/job/RunUnittests-race-amd64/2832/testReport/junit/github/com_juju_juju_cmd_jujud_agent/TestPackage/)). I've tested locally that this change also fixes that race, but I've added a unit test for the specific issue in this PR too.