### PR TITLE
Client: Refactor client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT := github.com/juju/http
 .PHONY: check-go check
 
 check:  check-go
-	go test -gocheck.v $(PROJECT)/...
+	go test --race -gocheck.v $(PROJECT)/...
 
 check-go:
 	$(eval GOFMT := $(strip $(shell gofmt -l .| sed -e "s/^/ /g")))

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/http/httputil"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -21,14 +22,16 @@ import (
 // and init() will no longer be needed.
 //
 // https://bugs.launchpad.net/juju/+bug/1888888
+//
+// TODO (stickupkid) This is terrible, I'm not kidding! This isn't yours to
+// touch!
 func init() {
 	defaultTransport := http.DefaultTransport.(*http.Transport)
 	// Call the HTTPDialShim for the DefaultTransport to
 	// facilitate testing use of OutgoingAccessAllowed.
-	installHTTPDialShim(defaultTransport)
+	defaultTransport = DialContextMiddleware(NewLocalDialBreaker(true))(defaultTransport)
 	// Call our own proxy function with the DefaultTransport.
-	installProxyShim(defaultTransport)
-	//registerFileProtocol(defaultTransport)
+	http.DefaultTransport = ProxyMiddleware(defaultTransport)
 }
 
 // HTTPClient represents an http.Client.
@@ -42,6 +45,117 @@ type Logger interface {
 	Tracef(message string, args ...interface{})
 }
 
+// Option to be passed into the transport construction to customize the
+// default transport.
+type Option func(*options)
+
+type options struct {
+	caCertificates           []string
+	cookieJar                http.CookieJar
+	disableKeepAlives        bool
+	skipHostnameVerification bool
+	tlsHandshakeTimeout      time.Duration
+	middlewares              []TransportMiddleware
+	httpClient               *http.Client
+	logger                   Logger
+}
+
+// WithCACertificates contains Authority certificates to be used to validate
+// certificates of cloud infrastructure components.
+// The contents are Base64 encoded x.509 certs.
+func WithCACertificates(value ...string) Option {
+	return func(opt *options) {
+		opt.caCertificates = value
+	}
+}
+
+// WithCookieJar is used to insert relevant cookies into every
+// outbound Request and is updated with the cookie values
+// of every inbound Response. The Jar is consulted for every
+// redirect that the Client follows.
+//
+// If Jar is nil, cookies are only sent if they are explicitly
+// set on the Request.
+func WithCookieJar(value http.CookieJar) Option {
+	return func(opt *options) {
+		opt.cookieJar = value
+	}
+}
+
+// WithDisableKeepAlives will disable HTTP keep alives, not TCP keep alives.
+// Disabling HTTP keep alives will only use the connection to the server for a
+// single HTTP request creating a lot of garbage for the collector.
+func WithDisableKeepAlives(value bool) Option {
+	return func(opt *options) {
+		opt.disableKeepAlives = value
+	}
+}
+
+// WithSkipHostnameVerification will skip hostname verification on the TLS/SSL
+// certificates.
+func WithSkipHostnameVerification(value bool) Option {
+	return func(opt *options) {
+		opt.skipHostnameVerification = value
+	}
+}
+
+// WithTLSHandshakeTimeout will modify how long a TLS handshake should take.
+// Setting the value to zero will mean that no timeout will occur.
+func WithTLSHandshakeTimeout(value time.Duration) Option {
+	return func(opt *options) {
+		opt.tlsHandshakeTimeout = value
+	}
+}
+
+// WithTransportMiddlewares allows the wrapping or modification of the existing
+// transport for a given client.
+// In an ideal world, all transports should be cloned to prevent the
+// modification of an existing client transport.
+func WithTransportMiddlewares(middlewares ...TransportMiddleware) Option {
+	return func(opt *options) {
+		opt.middlewares = middlewares
+	}
+}
+
+// WithHTTPClient allows to define the http.Client to use.
+func WithHTTPClient(value *http.Client) Option {
+	return func(opt *options) {
+		opt.httpClient = value
+	}
+}
+
+// WithLogger defines a logger to use with the client.
+func WithLogger(value Logger) Option {
+	return func(opt *options) {
+		opt.logger = value
+	}
+}
+
+// Create a options instance with default values.
+func newOptions() *options {
+	// In this case, use a default http.Client.
+	// Ideally we should always use the NewHTTPTLSTransport,
+	// however test suites such as JujuConnSuite and some facade
+	// tests rely on settings to the http.DefaultTransport for
+	// tests to run with different protocol scheme such as "test"
+	// and some replace the RoundTripper to answer test scenarios.
+	//
+	// https://bugs.launchpad.net/juju/+bug/1888888
+	defaultCopy := *http.DefaultClient
+
+	return &options{
+		disableKeepAlives:        false,
+		skipHostnameVerification: false,
+		middlewares: []TransportMiddleware{
+			DialContextMiddleware(NewLocalDialBreaker(true)),
+			FileProtocolMiddleware,
+			ProxyMiddleware,
+		},
+		httpClient: &defaultCopy,
+		logger:     loggo.GetLogger("http"),
+	}
+}
+
 // Client represents an http client.
 type Client struct {
 	HTTPClient
@@ -49,92 +163,63 @@ type Client struct {
 	logger Logger
 }
 
-// Config holds configuration for creating a new http client.
-type Config struct {
-	// CACertificates contains an optional list of Certificate
-	// Authority certificates to be used to validate certificates
-	// of cloud infrastructure components.
-	// The contents are Base64 encoded x.509 certs.
-	CACertificates []string
-
-	// Jar specifies the cookie jar.
-	//
-	// The Jar is used to insert relevant cookies into every
-	// outbound Request and is updated with the cookie values
-	// of every inbound Response. The Jar is consulted for every
-	// redirect that the Client follows.
-	//
-	// If Jar is nil, cookies are only sent if they are explicitly
-	// set on the Request.
-	Jar http.CookieJar
-
-	// SkipHostnameVerification indicates whether to use self-signed credentials
-	// and not try to verify the hostname on the TLS/SSL certificates.
-	SkipHostnameVerification bool
-
-	// Logger is used to provide logging with the provided Client.
-	// When logging level is set to Trace, the httptrace package is
-	// used to log details about any Get done.  If empty, a local
-	// logger is created.
-	Logger Logger
-}
-
 // NewClient returns a new juju http client defined
 // by the given config.
-func NewClient(cfg Config) *Client {
-	certCnt := len(cfg.CACertificates)
-	var hc *http.Client
+func NewClient(options ...Option) *Client {
+	opts := newOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	client := opts.httpClient
+	transport := DefaultHTTPTransportWithMiddlewares(opts.middlewares)
 	switch {
-	case certCnt > 0:
-		hc = clientWithCerts(cfg)
-	case cfg.SkipHostnameVerification:
-		hc = client(cfg)
-	default:
-		// In this case, use a default http.Client.
-		// Ideally we should always use the NewHttpTLSTransport,
-		// however test suites such as JujuConnSuite and some facade
-		// tests rely on settings to the http.DefaultTransport for
-		// tests to run with different protocol scheme such as "test"
-		// and some replace the RoundTripper to answer test scenarios.
-		//
-		// https://bugs.launchpad.net/juju/+bug/1888888
-		defaultCopy := *http.DefaultClient
-		hc = &defaultCopy
+	case len(opts.caCertificates) > 0:
+		transport = transportWithCerts(transport, opts.caCertificates, opts.skipHostnameVerification)
+	case opts.skipHostnameVerification:
+		transport = transportWithSkipVerify(transport, opts.skipHostnameVerification)
 	}
-	hc.Jar = cfg.Jar
-	c := &Client{
-		HTTPClient: hc,
-	}
-	if cfg.Logger == nil {
-		c.logger = loggo.GetLogger("http")
-	} else {
-		c.logger = cfg.Logger
-	}
-	return c
-}
+	client.Transport = transport
 
-func client(cfg Config) *http.Client {
-	return &http.Client{
-		Transport: NewHttpTLSTransport(&tls.Config{
-			InsecureSkipVerify: cfg.SkipHostnameVerification,
-		}),
+	if opts.cookieJar != nil {
+		client.Jar = opts.cookieJar
+	}
+	return &Client{
+		HTTPClient: client,
+		logger:     opts.logger,
 	}
 }
 
-func clientWithCerts(cfg Config) *http.Client {
-	if len(cfg.CACertificates) == 0 {
-		return nil
+func transportWithSkipVerify(defaultTransport *http.Transport, skipHostnameVerify bool) *http.Transport {
+	transport := defaultTransport
+	// We know that the DefaultHTTPTransport doesn't create a tls.Config here
+	// so we can safely do that here.
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: skipHostnameVerify,
 	}
+	// We're creating a new tls.Config, HTTP/2 requests will not work, force the
+	// client to create a HTTP/2 requests.
+	transport.ForceAttemptHTTP2 = true
+	return transport
+}
+
+func transportWithCerts(defaultTransport *http.Transport, caCerts []string, skipHostnameVerify bool) *http.Transport {
 	pool := x509.NewCertPool()
-	for _, cert := range cfg.CACertificates {
+	for _, cert := range caCerts {
 		pool.AppendCertsFromPEM([]byte(cert))
 	}
+
 	tlsConfig := SecureTLSConfig()
 	tlsConfig.RootCAs = pool
-	tlsConfig.InsecureSkipVerify = cfg.SkipHostnameVerification
-	return &http.Client{
-		Transport: NewHttpTLSTransport(tlsConfig),
-	}
+	tlsConfig.InsecureSkipVerify = skipHostnameVerify
+
+	transport := defaultTransport
+	transport.TLSClientConfig = tlsConfig
+
+	// We're creating a new tls.Config, HTTP/2 requests will not work, force the
+	// client to create a HTTP/2 requests.
+	transport.ForceAttemptHTTP2 = true
+	return transport
 }
 
 // Client returns the underlying http.Client.  Used in testing
@@ -170,6 +255,7 @@ func (c *Client) traceRequest(req *http.Request, url string) error {
 	if !c.logger.IsTraceEnabled() {
 		return nil
 	}
+
 	dump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		return errors.Trace(err)

--- a/client_test.go
+++ b/client_test.go
@@ -22,53 +22,8 @@ type clientSuite struct {
 var _ = gc.Suite(&clientSuite{})
 
 func (s *clientSuite) TestNewClient(c *gc.C) {
-	client := NewClient(Config{})
+	client := NewClient()
 	c.Assert(client, gc.NotNil)
-}
-
-var isLocalAddrTests = []struct {
-	addr    string
-	isLocal bool
-}{
-	{"localhost:456", true},
-	{"127.0.0.1:1234", true},
-	{"[::1]:4567", true},
-	{"localhost:smtp", true},
-	{"123.45.67.5", false},
-	{"0.1.2.3", false},
-	{"10.0.43.6:12345", false},
-	{":456", false},
-	{"12xz4.5.6", false},
-}
-
-func (s *clientSuite) TestIsLocalAddr(c *gc.C) {
-	for i, test := range isLocalAddrTests {
-		c.Logf("test %d: %v", i, test.addr)
-		c.Assert(isLocalAddr(test.addr), gc.Equals, test.isLocal)
-	}
-}
-
-type httpNoOutgoingAccessSuite struct {
-	testing.IsolationSuite
-}
-
-var _ = gc.Suite(&httpNoOutgoingAccessSuite{})
-
-func (s *httpNoOutgoingAccessSuite) TestInsecureClientNoAccess(c *gc.C) {
-	s.PatchValue(&OutgoingAccessAllowed, false)
-	cfg := Config{
-		SkipHostnameVerification: true,
-	}
-	client := NewClient(cfg)
-	_, err := client.Get(context.TODO(), "http://0.1.2.3:1234")
-	c.Assert(err, gc.ErrorMatches, `.*access to address "0.1.2.3:1234" not allowed`)
-}
-
-func (s *httpNoOutgoingAccessSuite) TestSecureClientNoAccess(c *gc.C) {
-	s.PatchValue(&OutgoingAccessAllowed, false)
-	client := NewClient(Config{})
-	_, err := client.Get(context.TODO(), "http://0.1.2.3:1234")
-	c.Assert(err, gc.ErrorMatches, `.*access to address "0.1.2.3:1234" not allowed`)
 }
 
 type httpSuite struct {
@@ -84,14 +39,13 @@ func (s *httpSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *httpSuite) TestInsecureClientAllowAccess(c *gc.C) {
-	cfg := Config{SkipHostnameVerification: true}
-	client := NewClient(cfg)
+	client := NewClient(WithSkipHostnameVerification(true))
 	_, err := client.Get(context.TODO(), s.server.URL)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *httpSuite) TestSecureClientAllowAccess(c *gc.C) {
-	client := NewClient(Config{})
+	client := NewClient()
 	_, err := client.Get(context.TODO(), s.server.URL)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -103,7 +57,8 @@ func (s *httpSuite) TestDefaultClientJarNotOverwritten(c *gc.C) {
 
 	jar, err := cookiejar.New(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	client := NewClient(Config{Jar: jar})
+
+	client := NewClient(WithCookieJar(jar))
 
 	hc := client.HTTPClient.(*http.Client)
 	c.Assert(hc.Jar, gc.Equals, jar)
@@ -137,24 +92,17 @@ func (s *httpTLSServerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *httpTLSServerSuite) TestValidatingClientGetter(c *gc.C) {
-	client := NewClient(Config{})
+	client := NewClient()
 	_, err := client.Get(context.TODO(), s.server.URL)
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*x509: certificate signed by unknown authority")
-
-	client1 := NewClient(Config{})
-	c.Assert(client1, gc.Not(gc.Equals), client)
 }
 
 func (s *httpTLSServerSuite) TestNonValidatingClientGetter(c *gc.C) {
-	cfg := Config{SkipHostnameVerification: true}
-	client := NewClient(cfg)
+	client := NewClient(WithSkipHostnameVerification(true))
 	resp, err := client.Get(context.TODO(), s.server.URL)
 	c.Assert(err, gc.IsNil)
 	_ = resp.Body.Close()
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
-
-	client1 := NewClient(cfg)
-	c.Assert(client1, gc.Not(gc.Equals), client)
 }
 
 func (s *httpTLSServerSuite) TestGetHTTPClientWithCertsVerify(c *gc.C) {
@@ -172,11 +120,11 @@ func (s *httpTLSServerSuite) testGetHTTPClientWithCerts(c *gc.C, skip bool) {
 		Bytes: s.server.Certificate().Raw,
 	})
 	c.Assert(err, gc.IsNil)
-	cfg := Config{
-		CACertificates:           []string{caPEM.String()},
-		SkipHostnameVerification: true,
-	}
-	client := NewClient(cfg)
+
+	client := NewClient(
+		WithCACertificates(caPEM.String()),
+		WithSkipHostnameVerification(true),
+	)
 	resp, err := client.Get(context.TODO(), s.server.URL)
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp.Body.Close(), gc.IsNil)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/http
+module github.com/juju/http/v2
 
 go 1.14
 
@@ -8,6 +8,7 @@ require (
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9 // indirect
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d // indirect
+	github.com/juju/http v0.0.0-20201019013536-69ae1d429836
 	github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 // indirect
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf // indirect
@@ -16,6 +17,7 @@ require (
 	github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 	gopkg.in/errgo.v1 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0b
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f h1:MCOvExGLpaSIzLYB4iQXEHP4jYVU6vmzLNQPdMVrxnM=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
+github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
+github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e h1:FdDd7bdI6cjq5vaoYlK1mfQYfF9sF2VZw8VEZMsl5t8=
@@ -44,6 +46,8 @@ github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20180214000028-650f4a345ab4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190222235706-ffb98f73852f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,100 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package http
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// FileProtocolMiddleware registers support for file:// URLs on the given transport.
+func FileProtocolMiddleware(transport *http.Transport) *http.Transport {
+	transport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+	return transport
+}
+
+// DialBreaker replicates a highly specialized CircuitBreaker pattern, which
+// takes into account the current address.
+type DialBreaker interface {
+	// Allowed checks to see if a given address is allowed.
+	Allowed(string) bool
+	// Trip will cause the DialBreaker to change the breaker state
+	Trip()
+}
+
+func isLocalAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return host == "localhost" || net.ParseIP(host).IsLoopback()
+}
+
+// DialContextMiddleware patches the default HTTP transport so
+// that it fails when an attempt is made to dial a non-local
+// host.
+func DialContextMiddleware(breaker DialBreaker) TransportMiddleware {
+	return func(transport *http.Transport) *http.Transport {
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if !breaker.Allowed(addr) {
+				return nil, errors.Errorf("access to address %q not allowed", addr)
+			}
+
+			return dialer.DialContext(ctx, network, addr)
+		}
+		return transport
+	}
+}
+
+// LocalDialBreaker defines a DialBreaker that when tripped only allows local
+// dials, anything else is prevented.
+type LocalDialBreaker struct {
+	allowOutgoingAccess bool
+}
+
+// NewLocalDialBreaker creates a new LocalDialBreaker with a default value.
+func NewLocalDialBreaker(allowOutgoingAccess bool) *LocalDialBreaker {
+	return &LocalDialBreaker{
+		allowOutgoingAccess: allowOutgoingAccess,
+	}
+}
+
+// Allowed checks to see if a dial is allowed to happen, or returns an error
+// stating why.
+func (b *LocalDialBreaker) Allowed(addr string) bool {
+	if b.allowOutgoingAccess {
+		return true
+	}
+	// If we're not allowing outgoing access, then only local addresses are
+	// allowed to be dialed. Check for local only addresses.
+	return isLocalAddr(addr)
+}
+
+// Trip inverts the local state of the DialBreaker.
+func (b *LocalDialBreaker) Trip() {
+	b.allowOutgoingAccess = !b.allowOutgoingAccess
+}
+
+// ProxyMiddleware adds a Proxy to the given transport. This implementation
+// uses the http.ProxyFromEnvironment.
+func ProxyMiddleware(transport *http.Transport) *http.Transport {
+	transport.Proxy = http.ProxyFromEnvironment
+	return transport
+}
+
+// ForceAttemptHTTP2Middleware forces a HTTP/2 connection if a non-zero
+// Dial, DialTLS, or DialContext func or TLSClientConfig is provided to the
+// Transport. Using any of these will render HTTP/2 disabled, so force the
+// client to use it for requests.
+func ForceAttemptHTTP2Middleware(transport *http.Transport) *http.Transport {
+	transport.ForceAttemptHTTP2 = true
+	return transport
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,103 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package http
+
+import (
+	"context"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type DialContextMiddlewareSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&DialContextMiddlewareSuite{})
+
+var isLocalAddrTests = []struct {
+	addr    string
+	isLocal bool
+}{
+	{"localhost:456", true},
+	{"127.0.0.1:1234", true},
+	{"[::1]:4567", true},
+	{"localhost:smtp", true},
+	{"123.45.67.5", false},
+	{"0.1.2.3", false},
+	{"10.0.43.6:12345", false},
+	{":456", false},
+	{"12xz4.5.6", false},
+}
+
+func (s *DialContextMiddlewareSuite) TestIsLocalAddr(c *gc.C) {
+	for i, test := range isLocalAddrTests {
+		c.Logf("test %d: %v", i, test.addr)
+		c.Assert(isLocalAddr(test.addr), gc.Equals, test.isLocal)
+	}
+}
+
+func (s *DialContextMiddlewareSuite) TestInsecureClientNoAccess(c *gc.C) {
+	client := NewClient(
+		WithTransportMiddlewares(
+			DialContextMiddleware(NewLocalDialBreaker(false)),
+		),
+		WithSkipHostnameVerification(true),
+	)
+	_, err := client.Get(context.TODO(), "http://0.1.2.3:1234")
+	c.Assert(err, gc.ErrorMatches, `.*access to address "0.1.2.3:1234" not allowed`)
+}
+
+func (s *DialContextMiddlewareSuite) TestSecureClientNoAccess(c *gc.C) {
+	client := NewClient(
+		WithTransportMiddlewares(
+			DialContextMiddleware(NewLocalDialBreaker(false)),
+		),
+	)
+	_, err := client.Get(context.TODO(), "http://0.1.2.3:1234")
+	c.Assert(err, gc.ErrorMatches, `.*access to address "0.1.2.3:1234" not allowed`)
+}
+
+type LocalDialBreakerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&LocalDialBreakerSuite{})
+
+func (s *LocalDialBreakerSuite) TestAllowed(c *gc.C) {
+	breaker := NewLocalDialBreaker(true)
+
+	for i, test := range isLocalAddrTests {
+		c.Logf("test %d: %v", i, test.addr)
+		allowed := breaker.Allowed(test.addr)
+		c.Assert(allowed, gc.Equals, true)
+	}
+}
+
+func (s *LocalDialBreakerSuite) TestLocalAllowed(c *gc.C) {
+	breaker := NewLocalDialBreaker(false)
+
+	for i, test := range isLocalAddrTests {
+		c.Logf("test %d: %v", i, test.addr)
+		allowed := breaker.Allowed(test.addr)
+		c.Assert(allowed, gc.Equals, test.isLocal)
+	}
+}
+
+func (s *LocalDialBreakerSuite) TestLocalAllowedAfterTrip(c *gc.C) {
+	breaker := NewLocalDialBreaker(true)
+
+	for i, test := range isLocalAddrTests {
+		c.Logf("test %d: %v", i, test.addr)
+		allowed := breaker.Allowed(test.addr)
+		c.Assert(allowed, gc.Equals, true)
+
+		breaker.Trip()
+
+		allowed = breaker.Allowed(test.addr)
+		c.Assert(allowed, gc.Equals, test.isLocal)
+
+		// Reset the breaker.
+		breaker.Trip()
+	}
+}

--- a/tls.go
+++ b/tls.go
@@ -41,18 +41,12 @@ func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
 // DefaultHTTPTransport creates a default transport with HTTP keep alives
 // disabled and proxy middleware enable.
 func DefaultHTTPTransport() *http.Transport {
-	return DefaultHTTPTransportWithMiddlewares([]TransportMiddleware{
-		ProxyMiddleware,
-	})
-}
-
-// DefaultHTTPTransportWithMiddlewares creates a default transport with HTTP
-// keep alives disabled and allows a slice of middlewares to be passed through.
-func DefaultHTTPTransportWithMiddlewares(middlewares []TransportMiddleware) *http.Transport {
 	return NewHTTPTLSTransport(TransportConfig{
 		DisableKeepAlives:   true,
-		TLSHandshakeTimeout: 30 * time.Second,
-		Middlewares:         middlewares,
+		TLSHandshakeTimeout: 20 * time.Second,
+		Middlewares: []TransportMiddleware{
+			ProxyMiddleware,
+		},
 	})
 }
 

--- a/tls.go
+++ b/tls.go
@@ -9,21 +9,51 @@ import (
 	"time"
 )
 
-// NewHttpTLSTransport returns a new http.Transport constructed with the TLS config
+// TransportMiddleware represents a way to add an adapter to the existing transport.
+type TransportMiddleware func(*http.Transport) *http.Transport
+
+// TransportConfig holds the configurable values for setting up a http
+// transport.
+type TransportConfig struct {
+	TLSConfig           *tls.Config
+	DisableKeepAlives   bool
+	TLSHandshakeTimeout time.Duration
+	Middlewares         []TransportMiddleware
+}
+
+// NewHTTPTLSTransport returns a new http.Transport constructed with the TLS config
 // and the necessary parameters for Juju.
-func NewHttpTLSTransport(tlsConfig *tls.Config) *http.Transport {
+func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
 	// See https://code.google.com/p/go/issues/detail?id=4677
 	// We need to force the connection to close each time so that we don't
 	// hit the above Go bug.
 	transport := &http.Transport{
-		TLSClientConfig:     tlsConfig,
-		DisableKeepAlives:   true,
-		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     config.TLSConfig,
+		DisableKeepAlives:   config.DisableKeepAlives,
+		TLSHandshakeTimeout: config.TLSHandshakeTimeout,
 	}
-	installHTTPDialShim(transport)
-	registerFileProtocol(transport)
-	installProxyShim(transport)
+	for _, middlewareFn := range config.Middlewares {
+		transport = middlewareFn(transport)
+	}
 	return transport
+}
+
+// DefaultHTTPTransport creates a default transport with HTTP keep alives
+// disabled and proxy middleware enable.
+func DefaultHTTPTransport() *http.Transport {
+	return DefaultHTTPTransportWithMiddlewares([]TransportMiddleware{
+		ProxyMiddleware,
+	})
+}
+
+// DefaultHTTPTransportWithMiddlewares creates a default transport with HTTP
+// keep alives disabled and allows a slice of middlewares to be passed through.
+func DefaultHTTPTransportWithMiddlewares(middlewares []TransportMiddleware) *http.Transport {
+	return NewHTTPTLSTransport(TransportConfig{
+		DisableKeepAlives:   true,
+		TLSHandshakeTimeout: 30 * time.Second,
+		Middlewares:         middlewares,
+	})
 }
 
 // knownGoodCipherSuites contains the list of secure cipher suites to use


### PR DESCRIPTION
The following change firstly bumps juju/http to v2, as this contains a
lot of breaking changes.

Secondly it introduces the concept of transport middleware. In order to
add additional middlewares in the future (thinking about retry and
metric transport wrappers), then we need to expose this to the consumer
of the library.

Part of that standardisation was to correctly setup a default transport
so that all subsquent transports use the same one. Instead of some using
a blank transport and others using a custom one.

The middleware concept then allows us to talk about concepts like
breakers, that prevent outgoing calls at a much higher level.

Lastly we moved from a fat config, to providing options that can be
sequenced togther, before passing it to the constructor. One benefit of
doing it this way is allowing us to create defaults in one location and
pass that through, rather than ad-hoc inline style.