### PR TITLE
Re-enable HTTP keep-alives now that net/http is fixed (as of Go 1.6!)

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,7 +88,8 @@ func WithCookieJar(value http.CookieJar) Option {
 
 // WithDisableKeepAlives will disable HTTP keep alives, not TCP keep alives.
 // Disabling HTTP keep alives will only use the connection to the server for a
-// single HTTP request creating a lot of garbage for the collector.
+// single HTTP request, slowing down subsequent requests and creating a lot of
+// garbage for the collector.
 func WithDisableKeepAlives(value bool) Option {
 	return func(opt *options) {
 		opt.disableKeepAlives = value
@@ -166,7 +167,6 @@ func newOptions() *options {
 	defaultCopy := *http.DefaultClient
 
 	return &options{
-		disableKeepAlives:        true,
 		tlsHandshakeTimeout:      20 * time.Second,
 		skipHostnameVerification: false,
 		middlewares: []TransportMiddleware{

--- a/client_test.go
+++ b/client_test.go
@@ -237,3 +237,17 @@ func (s *httpTLSServerSuite) testGetHTTPClientWithCerts(c *gc.C, skip bool) {
 	c.Assert(resp.Body.Close(), gc.IsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 }
+
+func (s *clientSuite) TestDisableKeepAlives(c *gc.C) {
+	client := NewClient()
+	transport := client.Client().Transport.(*http.Transport)
+	c.Assert(transport.DisableKeepAlives, gc.Equals, false)
+
+	client = NewClient(WithDisableKeepAlives(false))
+	transport = client.Client().Transport.(*http.Transport)
+	c.Assert(transport.DisableKeepAlives, gc.Equals, false)
+
+	client = NewClient(WithDisableKeepAlives(true))
+	transport = client.Client().Transport.(*http.Transport)
+	c.Assert(transport.DisableKeepAlives, gc.Equals, true)
+}

--- a/tls.go
+++ b/tls.go
@@ -24,9 +24,6 @@ type TransportConfig struct {
 // NewHTTPTLSTransport returns a new http.Transport constructed with the TLS config
 // and the necessary parameters for Juju.
 func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
-	// See https://code.google.com/p/go/issues/detail?id=4677
-	// We need to force the connection to close each time so that we don't
-	// hit the above Go bug.
 	transport := &http.Transport{
 		TLSClientConfig:     config.TLSConfig,
 		DisableKeepAlives:   config.DisableKeepAlives,
@@ -38,11 +35,10 @@ func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
 	return transport
 }
 
-// DefaultHTTPTransport creates a default transport with HTTP keep alives
-// disabled and proxy middleware enable.
+// DefaultHTTPTransport creates a default transport with proxy middleware
+// enabled.
 func DefaultHTTPTransport() *http.Transport {
 	return NewHTTPTLSTransport(TransportConfig{
-		DisableKeepAlives:   true,
 		TLSHandshakeTimeout: 20 * time.Second,
 		Middlewares: []TransportMiddleware{
 			ProxyMiddleware,

--- a/tls_test.go
+++ b/tls_test.go
@@ -133,3 +133,16 @@ nd0dgM/TfgtnuhbVS4ISkT4vZoSn84hOE7BG5rSPE+/q24Wv5gG0PI1sky8tmXzX
 juAEWSJVCSE0TK/mvBVdlyKOJoEgtfMcRfDQfA1rI9My0rU+/Y5A0w==
 -----END RSA PRIVATE KEY-----`
 )
+
+func (TLSSuite) TestDisableKeepAlives(c *gc.C) {
+	transport := DefaultHTTPTransport()
+	c.Assert(transport.DisableKeepAlives, gc.Equals, false)
+
+	transport = NewHTTPTLSTransport(TransportConfig{})
+	c.Assert(transport.DisableKeepAlives, gc.Equals, false)
+
+	transport = NewHTTPTLSTransport(TransportConfig{
+		DisableKeepAlives: true,
+	})
+	c.Assert(transport.DisableKeepAlives, gc.Equals, true)
+}


### PR DESCRIPTION
Way back in 2013 we had added a workaround to a net/http bug
(see https://github.com/golang/go/issues/4677, particularly rogpeppe's
comment) that involved closing the connection after each request:

* https://github.com/juju/utils/commit/e5796c6f4521df72a17cc850099231fc978e87e7
* https://github.com/juju/utils/commit/1d70ba995cde96221419b24c33f63607ebbc6e02

However, that net/http bug was fixed in 2016 (in
https://go-review.googlesource.com/c/go/+/3210/ which was included in
Go 1.6), so we can re-enable this and significantly speed subsequent
requests to the same host when using juju/http. For comparison, the
net/http package enables keep-alives by default; we had only disabled
them due to that bug.

Some numbers: a full request to the Charmhub API takes about 1s from
New Zealand (to London, I believe) due mainly to latency from the
initial TLS negotiation. With DisableKeepAlives, subsequent requests
were of course taking the same time -- now subsequent requests take
only ~350ms.

Also add tests to ensure DisableKeepAlives is off by default -- doesn't
really test the feature (that's "too hard" to do well), but at least
ensures the correct values are being passed to http.Transport.