### PR TITLE
fix:reasonable default http parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+/.idea

--- a/tls.go
+++ b/tls.go
@@ -19,10 +19,6 @@ type TransportConfig struct {
 	DisableKeepAlives   bool
 	TLSHandshakeTimeout time.Duration
 	Middlewares         []TransportMiddleware
-	MaxIdleConns        int
-	MaxIdleConnsPerHost int
-	MaxConnsPerHost     int
-	IdleConnTimeout     time.Duration
 }
 
 // NewHTTPTLSTransport returns a new http.Transport constructed with the TLS config
@@ -32,10 +28,11 @@ func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
 		TLSClientConfig:     config.TLSConfig,
 		DisableKeepAlives:   config.DisableKeepAlives,
 		TLSHandshakeTimeout: config.TLSHandshakeTimeout,
-		MaxIdleConns:        config.MaxIdleConns,
-		MaxIdleConnsPerHost: config.MaxIdleConnsPerHost,
-		MaxConnsPerHost:     config.MaxConnsPerHost,
-		IdleConnTimeout:     config.IdleConnTimeout,
+		// These are taken from DefaultTransport
+		// Setting them to 0 means that no idle connections will ever timeout
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 	for _, middlewareFn := range config.Middlewares {
 		transport = middlewareFn(transport)

--- a/tls.go
+++ b/tls.go
@@ -28,8 +28,9 @@ func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
 		TLSClientConfig:     config.TLSConfig,
 		DisableKeepAlives:   config.DisableKeepAlives,
 		TLSHandshakeTimeout: config.TLSHandshakeTimeout,
-		// These are taken from DefaultTransport
-		// Setting them to 0 means that no idle connections will ever timeout
+		// The following values are taken from Go standard library net/http.DefaultTransport
+		// (see https://pkg.go.dev/net/http#DefaultTransport), as of Go 1.20.
+		// Setting them to 0 means that no idle connections will ever timeout.
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/tls.go
+++ b/tls.go
@@ -19,6 +19,10 @@ type TransportConfig struct {
 	DisableKeepAlives   bool
 	TLSHandshakeTimeout time.Duration
 	Middlewares         []TransportMiddleware
+	MaxIdleConns        int
+	MaxIdleConnsPerHost int
+	MaxConnsPerHost     int
+	IdleConnTimeout     time.Duration
 }
 
 // NewHTTPTLSTransport returns a new http.Transport constructed with the TLS config
@@ -28,6 +32,10 @@ func NewHTTPTLSTransport(config TransportConfig) *http.Transport {
 		TLSClientConfig:     config.TLSConfig,
 		DisableKeepAlives:   config.DisableKeepAlives,
 		TLSHandshakeTimeout: config.TLSHandshakeTimeout,
+		MaxIdleConns:        config.MaxIdleConns,
+		MaxIdleConnsPerHost: config.MaxIdleConnsPerHost,
+		MaxConnsPerHost:     config.MaxConnsPerHost,
+		IdleConnTimeout:     config.IdleConnTimeout,
 	}
 	for _, middlewareFn := range config.Middlewares {
 		transport = middlewareFn(transport)

--- a/tls_test.go
+++ b/tls_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -145,4 +146,25 @@ func (TLSSuite) TestDisableKeepAlives(c *gc.C) {
 		DisableKeepAlives: true,
 	})
 	c.Assert(transport.DisableKeepAlives, gc.Equals, true)
+}
+
+func (TLSSuite) TestIdleConnections(c *gc.C) {
+	transport := DefaultHTTPTransport()
+	c.Check(transport.MaxIdleConns, gc.Equals, 0)
+	c.Check(transport.MaxIdleConnsPerHost, gc.Equals, 0)
+	c.Check(transport.MaxConnsPerHost, gc.Equals, 0)
+	c.Check(transport.IdleConnTimeout, gc.Equals, time.Duration(0))
+	transport.CloseIdleConnections()
+
+	transport = NewHTTPTLSTransport(TransportConfig{
+		MaxIdleConns:        10,
+		MaxIdleConnsPerHost: 2,
+		MaxConnsPerHost:     5,
+		IdleConnTimeout:     10 * time.Second,
+	})
+	c.Check(transport.MaxIdleConns, gc.Equals, 10)
+	c.Check(transport.MaxIdleConnsPerHost, gc.Equals, 2)
+	c.Check(transport.MaxConnsPerHost, gc.Equals, 5)
+	c.Check(transport.IdleConnTimeout, gc.Equals, 10*time.Second)
+	transport.CloseIdleConnections()
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -150,21 +150,8 @@ func (TLSSuite) TestDisableKeepAlives(c *gc.C) {
 
 func (TLSSuite) TestIdleConnections(c *gc.C) {
 	transport := DefaultHTTPTransport()
-	c.Check(transport.MaxIdleConns, gc.Equals, 0)
-	c.Check(transport.MaxIdleConnsPerHost, gc.Equals, 0)
-	c.Check(transport.MaxConnsPerHost, gc.Equals, 0)
-	c.Check(transport.IdleConnTimeout, gc.Equals, time.Duration(0))
-	transport.CloseIdleConnections()
-
-	transport = NewHTTPTLSTransport(TransportConfig{
-		MaxIdleConns:        10,
-		MaxIdleConnsPerHost: 2,
-		MaxConnsPerHost:     5,
-		IdleConnTimeout:     10 * time.Second,
-	})
-	c.Check(transport.MaxIdleConns, gc.Equals, 10)
-	c.Check(transport.MaxIdleConnsPerHost, gc.Equals, 2)
-	c.Check(transport.MaxConnsPerHost, gc.Equals, 5)
-	c.Check(transport.IdleConnTimeout, gc.Equals, 10*time.Second)
-	transport.CloseIdleConnections()
+	// Ensure that the default settings are reasonable
+	c.Check(transport.MaxIdleConns, gc.Equals, 100)
+	c.Check(transport.IdleConnTimeout, gc.Equals, 90*time.Second)
+	c.Check(transport.ExpectContinueTimeout, gc.Equals, 1*time.Second)
 }


### PR DESCRIPTION
When the standard library introduced Idle connection handling, they added it to the http.DefaultTransport. They also then introduced "if you initialize me with 0, do something sane", but only for MaxIdleConnsPerHost. If MaxIdleConns is 0, then it never times out idle connections. Similarly for IdleConnTimeout and ExpectContinueTimeout. We want to set these back to sane defaults.
Users that want to override them, can actually just override it in the returned `*http.Transport` they don't need to have the additional fields exposed in the constructor. Otherwise, we should be exposing more items, and then dealing with "how to interpret a 0 value", etc.)
